### PR TITLE
Allow psql port etc and update for current Pandas

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ bash postgres_make_concepts.sh
 
 Next, you'll need to build 3 additional materialized views necessary for this pipeline. To do this (again with
 schema edit permission), navigate to `utils` and run `bash postgres_make_extended_concepts.sh` followed by
-`psql -d mimic -f niv-durations.sql`.
+`psql -d mimic -f niv-durations.sql`.  (You can add extra `psql`
+connection parameters; see the start of
+`postgres_make_extended_concepts.sh` for details.)
 
 ## Step 4: Set Cohort Selection and Extraction Criteria
 

--- a/mimic_direct_extract.py
+++ b/mimic_direct_extract.py
@@ -236,7 +236,7 @@ def save_numerics(
     ).set_index('itemid')
 
     X['value'] = pd.to_numeric(X['value'], 'coerce')
-    X.astype({k: int for k in ID_COLS}, inplace=True)
+    X = X.astype({k: int for k in ID_COLS})
 
     to_hours = lambda x: max(0, x.days*24 + x.seconds // 3600)
 
@@ -300,9 +300,9 @@ def save_numerics(
 
     # Get the max time for each of the subjects so we can reconstruct!
     if subjects_filename is not None:
-        np.save(os.path.join(outPath, subjects_filename), data['subject_id'].as_matrix())
+        np.save(os.path.join(outPath, subjects_filename), data['subject_id'].to_numpy())
     if times_filename is not None: 
-        np.save(os.path.join(outPath, times_filename), data['max_hours'].as_matrix())
+        np.save(os.path.join(outPath, times_filename), data['max_hours'].to_numpy())
 
     #fix nan in count to be zero
     idx = pd.IndexSlice
@@ -321,7 +321,7 @@ def save_numerics(
     X = X.drop(columns = drop_col)
 
     ########
-    if dynamic_filename is not None: np.save(os.path.join(outPath, dynamic_filename), X.as_matrix())
+    if dynamic_filename is not None: np.save(os.path.join(outPath, dynamic_filename), X.to_numpy())
     if dynamic_hd5_filename is not None: X.to_hdf(os.path.join(outPath, dynamic_hd5_filename), 'X')
 
     return X

--- a/mimic_direct_extract.py
+++ b/mimic_direct_extract.py
@@ -231,8 +231,8 @@ def save_numerics(
 
     var_map = var_map[
         ['LEVEL2', 'ITEMID', 'LEVEL1']
-    ].rename_axis(
-        {'LEVEL2': 'LEVEL2', 'LEVEL1': 'LEVEL1', 'ITEMID': 'itemid'}, axis=1
+    ].rename(
+        columns={'LEVEL2': 'LEVEL2', 'LEVEL1': 'LEVEL1', 'ITEMID': 'itemid'}
     ).set_index('itemid')
 
     X['value'] = pd.to_numeric(X['value'], 'coerce')

--- a/mimic_direct_extract.py
+++ b/mimic_direct_extract.py
@@ -764,8 +764,8 @@ if __name__ == '__main__':
     args = vars(ap.parse_args())
     for key in sorted(args.keys()):
         print(key, args[key])
-    if args["psql_host"] == "SOCKET":
-        args["psql_host"] = None
+    if args['psql_host'] == "SOCKET":
+        args['psql_host'] = None
 
     if not isdir(args['resource_path']):
         raise ValueError("Invalid resource_path: %s" % args['resource_path'])

--- a/mimic_direct_extract.py
+++ b/mimic_direct_extract.py
@@ -805,7 +805,7 @@ if __name__ == '__main__':
         idx_hd5_filename = splitext(idx_hd5_filename)[0] + '_' + pop_size + splitext(idx_hd5_filename)[1]
 
     dbname = args['psql_dbname']
-    schema_name = args['psql_schema_name']
+    schema_name = 'public,' + args['psql_schema_name']
     query_args = {'dbname': dbname}
     if args['psql_host'] is not None: query_args['host'] = args['psql_host']
     if args['psql_port'] is not None: query_args['port'] = args['psql_port']

--- a/mimic_direct_extract.py
+++ b/mimic_direct_extract.py
@@ -732,6 +732,8 @@ if __name__ == '__main__':
 
     ap.add_argument('--psql_host', type=str, default=None,
                     help='Postgres host. Try "/var/run/postgresql/" for Unix domain socket errors.')
+    ap.add_argument('--psql_port', type=int, default=None,
+                    help='Postgres port. Defaults to 5432 if not provided.')
     ap.add_argument('--psql_dbname', type=str, default='mimic',
                     help='Postgres database name.')
     ap.add_argument('--psql_schema_name', type=str, default='mimiciii',
@@ -804,6 +806,7 @@ if __name__ == '__main__':
     schema_name = args['psql_schema_name']
     query_args = {'dbname': dbname}
     if args['psql_host'] is not None: query_args['host'] = args['psql_host']
+    if args['psql_port'] is not None: query_args['port'] = args['psql_port']
     if args['psql_user'] is not None: query_args['user'] = args['psql_user']
     if args['psql_password'] is not None: query_args['password'] = args['psql_password']
 

--- a/mimic_direct_extract.py
+++ b/mimic_direct_extract.py
@@ -146,8 +146,8 @@ def save_pop(
 def get_variable_mapping(mimic_mapping_filename):
     # Read in the second level mapping of the itemids
     var_map = pd.read_csv(mimic_mapping_filename, index_col=None)
-    var_map = var_map.ix[(var_map['LEVEL2'] != '') & (var_map['COUNT']>0)]
-    var_map = var_map.ix[(var_map['STATUS'] == 'ready')]
+    var_map = var_map[(var_map['LEVEL2'] != '') & (var_map['COUNT']>0)]
+    var_map = var_map[(var_map['STATUS'] == 'ready')]
     var_map['ITEMID'] = var_map['ITEMID'].astype(int)
 
     return var_map

--- a/mimic_direct_extract.py
+++ b/mimic_direct_extract.py
@@ -764,6 +764,8 @@ if __name__ == '__main__':
     args = vars(ap.parse_args())
     for key in sorted(args.keys()):
         print(key, args[key])
+    if args["psql_host"] == "SOCKET":
+        args["psql_host"] = None
 
     if not isdir(args['resource_path']):
         raise ValueError("Invalid resource_path: %s" % args['resource_path'])

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -37,7 +37,7 @@ build_concepts_mimic_code: setup_user_env.sh clone_mimic_code_repo
 	{ \
 	source ./setup_user_env.sh; \
 	cd ${MIMIC_CODE_DIR}/concepts; \
-	psql -U ${DBUSER} "${DBSTRING}" -h ${HOST} -f ./make-concepts.sql; \
+	psql "${DBSTRING}" -f ./make-concepts.sql; \
 	cd ../../MIMIC_Extract/utils; \
 	}
 
@@ -45,9 +45,9 @@ build_concepts_mimic_code: setup_user_env.sh clone_mimic_code_repo
 build_extra_concepts: setup_user_env.sh niv-durations.sql crystalloid-bolus.sql colloid-bolus.sql
 	{ \
 	source ./setup_user_env.sh; \
-	psql -U ${DBUSER} "${DBSTRING}" -h ${HOST} -f ./niv-durations.sql; \
-	psql -U ${DBUSER} "${DBSTRING}" -h ${HOST} -f ./crystalloid-bolus.sql; \
-	psql -U ${DBUSER} "${DBSTRING}" -h ${HOST} -f ./colloid-bolus.sql; \
+	psql "${DBSTRING}" -f ./niv-durations.sql; \
+	psql "${DBSTRING}" -f ./crystalloid-bolus.sql; \
+	psql "${DBSTRING}" -f ./colloid-bolus.sql; \
 	}
 
 #=== Env Checks

--- a/utils/build_curated_from_psql.sh
+++ b/utils/build_curated_from_psql.sh
@@ -26,4 +26,5 @@ python -u $MIMIC_EXTRACT_CODE_DIR/mimic_direct_extract.py \
     --pop_size $POP_SIZE \
     --psql_password $PGPASSWORD \
     --psql_host $HOST \
+    --psql_port $PORT \
     --min_percent 0 \

--- a/utils/build_curated_from_psql.sh
+++ b/utils/build_curated_from_psql.sh
@@ -24,7 +24,8 @@ python -u $MIMIC_EXTRACT_CODE_DIR/mimic_direct_extract.py \
     --exit_after_loading 0 \
     --plot_hist 0 \
     --pop_size $POP_SIZE \
-    --psql_password $PGPASSWORD \
+    --psql_user $DBUSER \
+    --psql_password $DBPASSWORD \
     --psql_host $HOST \
     --psql_port $PORT \
     --min_percent 0 \

--- a/utils/postgres_make_extended_concepts.sh
+++ b/utils/postgres_make_extended_concepts.sh
@@ -1,16 +1,22 @@
 # This file makes tables for the concepts in this subfolder.
 # Be sure to run postgres-functions.sql first, as the concepts rely on those function definitions.
 # Note that this may take a large amount of time and hard drive space.
+#
+# Exporting DBCONNEXTRA before calling this script will add this to the
+# connection string.  For example, running:
+# DBCONNEXTRA="user=mimic password=mimic" bash postgres_make_extended_concepts.sh
+# will add these settings to all of the psql calls.  (Note that "dbname"
+# and "search_path" do not need to be set.)
 
 # string replacements are necessary for some queries
-export REGEX_DATETIME_DIFF="s/DATETIME_DIFF\((.+?),\s?(.+?),\s?(DAY|MINUTE|SECOND|HOUR|YEAR)\)/DATETIME_DIFF(\1, \2, '\3')/g"
-export REGEX_SCHEMA='s/`physionet-data.(mimiciii_clinical|mimiciii_derived|mimiciii_notes).(.+?)`/\2/g'
-export CONNSTR='-d mimic'
+REGEX_DATETIME_DIFF="s/DATETIME_DIFF\((.+?),\s?(.+?),\s?(DAY|MINUTE|SECOND|HOUR|YEAR)\)/DATETIME_DIFF(\1, \2, '\3')/g"
+REGEX_SCHEMA='s/`physionet-data.(mimiciii_clinical|mimiciii_derived|mimiciii_notes).(.+?)`/\2/g'
+CONNSTR="dbname=mimic $DBCONNEXTRA"
 
 # this is set as the search_path variable for psql
 # a search path of "public,mimiciii" will search both public and mimiciii
 # schemas for data, but will create tables on the public schema
-export PSQL_PREAMBLE='SET search_path TO public,mimiciii'
+PSQL_PREAMBLE='SET search_path TO public,mimiciii'
 
 echo ''
 echo '==='
@@ -21,7 +27,7 @@ echo '==='
 echo ''
 
 echo 'Directory 5 of 9: fluid_balance'
-{ echo "${PSQL_PREAMBLE}; DROP TABLE IF EXISTS colloid_bolus; CREATE TABLE colloid_bolus AS "; cat $MIMIC_CODE_DIR/concepts/fluid_balance/colloid_bolus.sql; } | sed -r -e "${REGEX_DATETIME_DIFF}" | sed -r -e "${REGEX_SCHEMA}" | psql ${CONNSTR}
-{ echo "${PSQL_PREAMBLE}; DROP TABLE IF EXISTS crystalloid_bolus; CREATE TABLE crystalloid_bolus AS "; cat $MIMIC_CODE_DIR/concepts/fluid_balance/crystalloid_bolus.sql; } | sed -r -e "${REGEX_DATETIME_DIFF}" | sed -r -e "${REGEX_SCHEMA}" | psql ${CONNSTR}
+{ echo "${PSQL_PREAMBLE}; DROP TABLE IF EXISTS colloid_bolus; CREATE TABLE colloid_bolus AS "; cat $MIMIC_CODE_DIR/concepts/fluid_balance/colloid_bolus.sql; } | sed -r -e "${REGEX_DATETIME_DIFF}" | sed -r -e "${REGEX_SCHEMA}" | psql "${CONNSTR}"
+{ echo "${PSQL_PREAMBLE}; DROP TABLE IF EXISTS crystalloid_bolus; CREATE TABLE crystalloid_bolus AS "; cat $MIMIC_CODE_DIR/concepts/fluid_balance/crystalloid_bolus.sql; } | sed -r -e "${REGEX_DATETIME_DIFF}" | sed -r -e "${REGEX_SCHEMA}" | psql "${CONNSTR}"
 
 echo 'Finished creating tables.'

--- a/utils/setup_user_env.sh
+++ b/utils/setup_user_env.sh
@@ -11,13 +11,13 @@ mkdir -p $MIMIC_EXTRACT_OUTPUT_DIR
 export DBUSER=mimic
 export DBNAME=mimic
 export SCHEMA=mimiciii
-export HOST=localhost
+export HOST=SOCKET
 export PORT=5432
 export PGPASSWORD=mimic
 
-export DBSTRING="host=$HOST port=$PORT user=$DBUSER password=$DBPASSWORD dbname=$DBNAME options=--search_path=$SCHEMA"
-
-export PGHOST=$HOST
-export PGPORT=$PORT
-export PGUSER=$DBUSER
-
+if [ $HOST = SOCKET ]
+then
+    export DBSTRING="port=$PORT user=$DBUSER password=$DBPASSWORD dbname=$DBNAME options=--search_path=$SCHEMA"
+else
+    export DBSTRING="host=$HOST port=$PORT user=$DBUSER password=$DBPASSWORD dbname=$DBNAME options=--search_path=$SCHEMA"
+fi

--- a/utils/setup_user_env.sh
+++ b/utils/setup_user_env.sh
@@ -10,10 +10,10 @@ mkdir -p $MIMIC_EXTRACT_OUTPUT_DIR
 
 export DBUSER=mimic
 export DBNAME=mimic
+export DBPASSWORD=mimic
 export SCHEMA=mimiciii
 export HOST=SOCKET
 export PORT=5432
-export PGPASSWORD=mimic
 
 if [ $HOST = SOCKET ]
 then

--- a/utils/setup_user_env.sh
+++ b/utils/setup_user_env.sh
@@ -8,14 +8,16 @@ export MIMIC_DATA_DIR=$MIMIC_EXTRACT_CODE_DIR/data/
 export MIMIC_EXTRACT_OUTPUT_DIR=$MIMIC_DATA_DIR/curated/
 mkdir -p $MIMIC_EXTRACT_OUTPUT_DIR
 
-export DBUSER=bnestor
+export DBUSER=mimic
 export DBNAME=mimic
 export SCHEMA=mimiciii
-export HOST=mimic
-export DBSTRING="dbname=$DBNAME options=--search_path=$SCHEMA"
-alias psql="psql -h $HOST -U $DBUSER "
+export HOST=localhost
+export PORT=5432
+export PGPASSWORD=mimic
+
+export DBSTRING="host=$HOST port=$PORT user=$DBUSER password=$DBPASSWORD dbname=$DBNAME options=--search_path=$SCHEMA"
 
 export PGHOST=$HOST
+export PGPORT=$PORT
 export PGUSER=$DBUSER
 
-export PGPASSWORD=$1


### PR DESCRIPTION
Hi,

Thanks for creating this tool!

After a fair amount of effort, I managed to get the MIMIC_Extract command: `make build_curated_from_psql` (in the `utils` directory) to work. The key issues were:

* I had used the https://github.com/MIT-LCP/mimic-code repository to build the PostgreSQL database for MIMIC-III (at least with some minor modifications described in https://github.com/MIT-LCP/mimic-code/pull/1195). But that meant that I had a new user and password and so on, but the MIMIC_Extract scripts could not handle this. So I have made some modifications to various scripts to allow for this. (There was also an issue that `utils/setup_user_env.sh` expected the password as the first argument, but it was never called with an argument by the other scripts.)
* The scripts were written for Pandas < 0.20, and several methods have been removed from Pandas >= 1.0. So I have updated the `mimic_direct_extract.py` script to handle modern versions of Pandas.
* The mimic-code concept scripts place the concepts in the `public` schema, but `mimic_direct_extract.py` only looked in `mimiciii`. So I have modified the code to change the `search_path` to include `public`.

I'm sorry that this is a rather big patch; it would have been nicer to split it into separate patches, but I couldn't work on either part without fixing the other.