### PR TITLE
Solving build error by updating schema - "relation xxx does not exist"

### DIFF
--- a/SQL_Queries/codes.sql
+++ b/SQL_Queries/codes.sql
@@ -1,8 +1,9 @@
+SET SEARCH_PATH TO 'public,mimiciii';
 SELECT
     i.icustay_id, d.subject_id, d.hadm_id,
     array_agg(d.icd9_code ORDER BY seq_num ASC) AS icd9_codes
-FROM mimiciii.diagnoses_icd d 
-    LEFT OUTER JOIN (SELECT ccs_matched_id, icd9_code from public.ccs_dx) c
+FROM diagnoses_icd d 
+    LEFT OUTER JOIN (SELECT ccs_matched_id, icd9_code from ccs_dx) c
     ON c.icd9_code = d.icd9_code
     INNER JOIN icustays i
     ON i.hadm_id = d.hadm_id AND i.subject_id = d.subject_id

--- a/SQL_Queries/codes.sql
+++ b/SQL_Queries/codes.sql
@@ -1,4 +1,4 @@
-SET SEARCH_PATH TO 'public,mimiciii';
+SET SEARCH_PATH TO public,mimiciii;
 SELECT
     i.icustay_id, d.subject_id, d.hadm_id,
     array_agg(d.icd9_code ORDER BY seq_num ASC) AS icd9_codes

--- a/SQL_Queries/codes.sql
+++ b/SQL_Queries/codes.sql
@@ -2,7 +2,7 @@ SELECT
     i.icustay_id, d.subject_id, d.hadm_id,
     array_agg(d.icd9_code ORDER BY seq_num ASC) AS icd9_codes
 FROM mimiciii.diagnoses_icd d 
-    LEFT OUTER JOIN (SELECT ccs_matched_id, icd9_code from mimiciii.ccs_dx) c
+    LEFT OUTER JOIN (SELECT ccs_matched_id, icd9_code from public.ccs_dx) c
     ON c.icd9_code = d.icd9_code
     INNER JOIN icustays i
     ON i.hadm_id = d.hadm_id AND i.subject_id = d.subject_id

--- a/SQL_Queries/debug_statics.sql
+++ b/SQL_Queries/debug_statics.sql
@@ -1,5 +1,5 @@
 \echo "This file is just for debugging"
-SET search_path TO mimiciii;
+SET search_path TO public,mimiciii;
 select distinct
     i.subject_id,
     i.hadm_id,

--- a/mimic_direct_extract.py
+++ b/mimic_direct_extract.py
@@ -734,7 +734,7 @@ if __name__ == '__main__':
                     help='Postgres host. Try "/var/run/postgresql/" for Unix domain socket errors.')
     ap.add_argument('--psql_dbname', type=str, default='mimic',
                     help='Postgres database name.')
-    ap.add_argument('--psql_schema_name', type=str, default='mimiciii',
+    ap.add_argument('--psql_schema_name', type=str, default='public,mimiciii',
                     help='Postgres database name.')
     ap.add_argument('--psql_user', type=str, default=None,
                     help='Postgres user.')

--- a/mimic_querier.py
+++ b/mimic_querier.py
@@ -25,7 +25,7 @@ class MIMIC_Querier():
         self,
         exclusion_criteria_template_vars={},
         query_args={}, # passed wholesale to psycopg2.connect
-        schema_name='mimiciii'
+        schema_name='public,mimiciii'
     ):
         """ A class to facilitate repeated Queries to a MIMIC psql database """
         self.exclusion_criteria_template_vars = {}

--- a/utils/niv-durations.sql
+++ b/utils/niv-durations.sql
@@ -4,7 +4,7 @@
 -- events can then be used for various purposes: calculating the total duration
 -- of mechanical ventilation, cross-checking values (e.g. PaO2:FiO2 on vent), etc
 
-SET SEARCH_PATH TO 'public,mimiciii';
+SET SEARCH_PATH TO public,mimiciii;
 
 -- The query's logic is roughly:
 --    1) The presence of a mechanical ventilation setting starts a new ventilation event

--- a/utils/niv-durations.sql
+++ b/utils/niv-durations.sql
@@ -4,7 +4,7 @@
 -- events can then be used for various purposes: calculating the total duration
 -- of mechanical ventilation, cross-checking values (e.g. PaO2:FiO2 on vent), etc
 
-SET SEARCH_PATH TO 'mimiciii';
+SET SEARCH_PATH TO 'public,mimiciii';
 
 -- The query's logic is roughly:
 --    1) The presence of a mechanical ventilation setting starts a new ventilation event

--- a/utils/setup_user_env.sh
+++ b/utils/setup_user_env.sh
@@ -10,7 +10,7 @@ mkdir -p $MIMIC_EXTRACT_OUTPUT_DIR
 
 export DBUSER=bnestor
 export DBNAME=mimic
-export SCHEMA=mimiciii
+export SCHEMA=public,mimiciii
 export HOST=mimic
 export DBSTRING="dbname=$DBNAME options=--search_path=$SCHEMA"
 alias psql="psql -h $HOST -U $DBUSER "


### PR DESCRIPTION
Hi,
Thanks for maintaining this repo.

It helped many people working on MIMIC-related research, and still many people are using it.
However, it looks like that MIT-LCP has changed their view generation code to create concepts in the `public` schema, not the `mimiciii` schema. 

Due to a schema change, people are facing build error as query cannot find generated concepts.
>  #65 relation **"mimiciii.ccs_dx"** does not exist
#18 Getting "relation **"icustay_detail"** does not exist" when running `make build_curated_from_psql`

Adding option `--psql_schema_name public,mimic` does not solve the problem because there are queries with hard-coded schema.

- **As a solution, I simply add `public` schema to search path of codes and queries.**

I've tested build instructions and it worked fine.
Hopefully, this will help people struggling with error and not to make this repo outdated.


