### PR TITLE
Remove fixed learning rate from Train_Model

### DIFF
--- a/notebooks/mmd_grud_utils.py
+++ b/notebooks/mmd_grud_utils.py
@@ -228,7 +228,6 @@ def Train_Model(
     loss_CEL=torch.nn.CrossEntropyLoss()
     loss_L1 = torch.nn.L1Loss()
     
-    learning_rate = 0.001
 #     optimizer = torch.optim.RMSprop(model.parameters(), lr = learning_rate, alpha=0.99)
     optimizer = torch.optim.Adam(model.parameters(), lr=learning_rate)
     use_gpu = False#torch.cuda.is_available()


### PR DESCRIPTION
Train_Model improperly fixed the learning rate inside the method and ignored the input argument. This defeats the hyperparameter search in the model notebooks.